### PR TITLE
Use orb release v0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
     docker:
       - image: cimg/base:2024.02
     environment:
-      OPENFIRE_VERSION_DOTS: "4.8.1"
-      OPENFIRE_VERSION_DASHES: "4_8_1"
+      OPENFIRE_VERSION_DOTS: "4.8.3"
+      OPENFIRE_VERSION_DASHES: "4_8_3"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 orbs:
-    interop-test: interop-test/tests@dev:alpha
+    interop-test: xmpp-interop-tests/test@0.1.0
 
 jobs:
   build: # Not a real build, but it could be


### PR DESCRIPTION
- Updates name (as per https://github.com/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb/issues/8)
- Sets version for use at v0.1.0, which will exist soon (due to a bug in the underlying Smack lib)
- Updates Openfire to v4.8.3